### PR TITLE
Fixed vertical resolution viewport

### DIFF
--- a/lib/fixed_vertical_resolution_viewport.dart
+++ b/lib/fixed_vertical_resolution_viewport.dart
@@ -1,9 +1,8 @@
-import 'package:flame/components.dart';
 import 'package:flame/extensions.dart';
 import 'package:flame/game.dart';
 
 class FixedVerticalResolutionViewport extends Viewport {
-  late double effectiveHeight;
+  final double effectiveHeight;
 
   final Vector2 _scaledSize = Vector2.zero();
   Vector2 get scaledSize => _scaledSize.clone();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
+import 'package:flame/src/game/camera/viewport.dart' as flameViewport;
 import 'package:flame/input.dart';
 import 'package:flame/sprite.dart';
 import 'package:flutter/foundation.dart';
@@ -11,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:moonlander/components/map_component.dart';
 import 'package:moonlander/components/pause_component.dart';
 import 'package:moonlander/components/rocket_component.dart';
+import 'package:moonlander/viewport.dart';
 import 'package:moonlander/widgets/pause_menu.dart';
 
 Future<void> main() async {
@@ -50,6 +52,8 @@ class MoonlanderGame extends FlameGame
         HasTappableComponents,
         HasKeyboardHandlerComponents,
         HasDraggableComponents {
+  late final flameViewport.Viewport viewport;
+
   /// Depending on the active overlay state we turn of the engine or not.
   void onOverlayChanged() {
     if (overlays.isActive('pause')) {
@@ -87,6 +91,7 @@ class MoonlanderGame extends FlameGame
       columns: 6,
       rows: 1,
     );
+    camera.viewport = FixedVerticalResolutionViewport(800);
 
     ///Ensure our joystick knob is between 50 and 100 based on view height
     ///Important its based on device size not viewport size

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,8 +52,6 @@ class MoonlanderGame extends FlameGame
         HasTappableComponents,
         HasKeyboardHandlerComponents,
         HasDraggableComponents {
-  late final flameViewport.Viewport viewport;
-
   /// Depending on the active overlay state we turn of the engine or not.
   void onOverlayChanged() {
     if (overlays.isActive('pause')) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,6 @@ import 'dart:math';
 import 'package:flame/components.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
-import 'package:flame/src/game/camera/viewport.dart' as flameViewport;
 import 'package:flame/input.dart';
 import 'package:flame/sprite.dart';
 import 'package:flutter/foundation.dart';
@@ -12,7 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:moonlander/components/map_component.dart';
 import 'package:moonlander/components/pause_component.dart';
 import 'package:moonlander/components/rocket_component.dart';
-import 'package:moonlander/viewport.dart';
+import 'package:moonlander/fixed_vertical_resolution_viewport.dart';
 import 'package:moonlander/widgets/pause_menu.dart';
 
 Future<void> main() async {

--- a/lib/viewport.dart
+++ b/lib/viewport.dart
@@ -1,0 +1,79 @@
+import 'package:flame/components.dart';
+import 'package:flame/extensions.dart';
+import 'package:flame/game.dart';
+
+class FixedVerticalResolutionViewport extends Viewport {
+  late double effectiveHeight;
+
+  final Vector2 _scaledSize = Vector2.zero();
+  Vector2 get scaledSize => _scaledSize.clone();
+
+  final Vector2 _resizeOffset = Vector2.zero();
+  Vector2 get resizeOffset => _resizeOffset.clone();
+
+  late double _scale;
+  double get scale => _scale;
+
+  /// The matrix used for scaling and translating the canvas
+  final Matrix4 _transform = Matrix4.identity();
+
+  /// The Rect that is used to clip the canvas
+  late Rect _clipRect;
+
+  FixedVerticalResolutionViewport(this.effectiveHeight);
+
+  @override
+  void resize(Vector2 newCanvasSize) {
+    canvasSize = newCanvasSize.clone();
+
+    _scale = canvasSize!.y / effectiveHeight;
+
+    _scaledSize
+      ..setFrom(effectiveSize)
+      ..scale(_scale);
+    _resizeOffset
+      ..setFrom(canvasSize!)
+      ..sub(_scaledSize)
+      ..scale(0.5);
+
+    _clipRect = _resizeOffset & _scaledSize;
+
+    _transform
+      ..setIdentity()
+      ..translate(_resizeOffset.x, _resizeOffset.y)
+      ..scale(_scale, _scale, 1);
+  }
+
+  @override
+  void render(Canvas c, void Function(Canvas) renderGame) {
+    c
+      ..save()
+      ..clipRect(_clipRect)
+      ..transform(_transform.storage);
+    renderGame(c);
+    c.restore();
+  }
+
+  @override
+  Vector2 projectVector(Vector2 viewportCoordinates) {
+    return (viewportCoordinates * _scale)..add(_resizeOffset);
+  }
+
+  @override
+  Vector2 unprojectVector(Vector2 screenCoordinates) {
+    return (screenCoordinates - _resizeOffset)..scale(1 / _scale);
+  }
+
+  @override
+  Vector2 scaleVector(Vector2 viewportCoordinates) {
+    return viewportCoordinates * scale;
+  }
+
+  @override
+  Vector2 unscaleVector(Vector2 screenCoordinates) {
+    return screenCoordinates / scale;
+  }
+
+  @override
+  Vector2 get effectiveSize => Vector2(canvasSize!.x / _scale, effectiveHeight);
+}


### PR DESCRIPTION
The viewport implementation we discussed with Christian.

`main.dart` code copied straight up from the [official flame example](https://github.com/flame-engine/flame/tree/main/examples/lib/stories/camera_and_viewport), viewport code is a clone of [`FixedResolutionViewport`](https://github.com/flame-engine/flame/blob/e8cd76355e4b6bc41cc3c34d5398267d1a765315/packages/flame/lib/src/game/camera/viewport.dart) with minor changes.

However, it seems like currently, at least with the code above, Flame doesn't account for viewport transformations for input events, meaning the button and the stick are not logically where they should be.