### PR TITLE
Improved collision side detection code

### DIFF
--- a/lib/components/rocket_component.dart
+++ b/lib/components/rocket_component.dart
@@ -283,38 +283,33 @@ class RocketComponent extends SpriteAnimationGroupComponent<RocketState>
       return;
     }
     final hitBox = hitboxes.first;
-    final leftHit = Rect.fromLTWH(
-      hitBox.position.x,
-      hitBox.position.y,
-      hitBox.size.x * 0.5,
-      hitBox.size.y * 0.7,
-    );
-    final rightHit = Rect.fromLTWH(
-      hitBox.position.x + hitBox.size.x * 0.5,
-      hitBox.position.y,
-      hitBox.size.x * 0.5,
-      hitBox.size.y * 0.7,
-    );
-    final bottomHit = Rect.fromLTWH(
-      hitBox.position.x,
-      hitBox.position.y + hitBox.size.y * 0.7,
-      hitBox.size.x,
-      hitBox.size.y * 0.7,
-    );
-    debugPrint("Left: " + leftHit.toString());
-    debugPrint("Right: " + rightHit.toString());
-    debugPrint("Bottom: " + bottomHit.toString());
+
     for (final point in intersectionPoints) {
-      final hitRec = point.toPositionedRect(Vector2.all(1));
-      debugPrint('Hit rect: ' + hitRec.toString());
-      if (leftHit.intersect(hitRec).size.isEmpty == false) {
-        debugPrint('Hit left');
-      } else if (rightHit.intersect(hitRec).size.isEmpty == false) {
-        debugPrint('Hit right');
-      } else if (bottomHit.intersect(hitRec).size.isEmpty == false) {
-        debugPrint('Hit bottom');
+      // Calculate which side of the hitbox had the collision
+      final vectorUp = Vector2(0, -1);
+      final relativeIntersectionPoint = (point - hitBox.position).normalized();
+      final angle = vectorUp.angleToSigned(relativeIntersectionPoint);
+      var angleDeg = degrees(angle);
+
+      // Fix for the angleToSigned method returning values form -180 to 180
+      if (angleDeg < 0) angleDeg = 360 + angleDeg;
+
+      // Print side depending on angle (from 0 to 360)
+      print('Collision at $angleDeg');
+      if (angleDeg >= (360 - 45) || angleDeg <= 45) {
+        print('Top');
+      }
+      if (angleDeg >= 45 && angleDeg <= 135) {
+        print('Right');
+      }
+      if (angleDeg >= 135 && angleDeg <= 225) {
+        print('Bottom');
+      }
+      if (angleDeg >= 225 && angleDeg <= 315) {
+        print('Left');
       }
     }
+
     if (other is LineComponent) {
       _loose();
     }


### PR DESCRIPTION
As Christian asked, I fixed the collision side detection code, making it much smaller and easier to read.
One note: right now it doesn't take into account lander's **UP** as `up` for calculations. That means that the **BOTTOM** will always be the direction of the gravity.

If other behaviors are needed (let's say, it's important for the lander to also detect bottom properly when turning), then it's easy to fix — just replace the `vectorUp` variable with the lander's local `up` relative to the world.